### PR TITLE
chore: add Austria (AT)

### DIFF
--- a/src/countries.ts
+++ b/src/countries.ts
@@ -218,6 +218,24 @@ export const countries: Country[] = [
     "isoCode": "036"
   },
   {
+    "label": "Austria",
+    "code": "AT",
+    "capital": "Vienna",
+    "region": "EU",
+    "currency": {
+      "code": "EUR",
+      "label": "Euro",
+      "symbol": "€"
+    },
+    "language": {
+      "code": "de",
+      "label": "German"
+    },
+    "flag": "https://flagcdn.com/48x36/at.png",
+    "countryCode": "+43",
+    "isoCode": "040"
+  },
+  {
     "label": "Azerbaijan",
     "code": "AZ",
     "capital": "Baku",


### PR DESCRIPTION
Austria is missing from the countries list, so I added it. I confirmed the codes with https://www.iso.org/obp/ui/#iso:code:3166:AT and https://en.wikipedia.org/wiki/Telephone_numbers_in_Austria